### PR TITLE
Add accent color and hover color to order-btn and order-form__submit-btn

### DIFF
--- a/src/sass/components/_order-btn.scss
+++ b/src/sass/components/_order-btn.scss
@@ -6,15 +6,19 @@
   text-transform: uppercase;
   display: inline-block;
   text-align: center;
-  background: $background-btn;
+  background: $accent-color;
   box-shadow: $btn-shadow;
   border-radius: 30.5px;
   padding: 16px 32px;
-  color: $accent-color;
+  color: $primary-white-color;
   cursor: pointer;
   transition: box-shadow $main-duration $timing-function;
+  transition: background, $main-duration $timing-function;
+
   &:hover,
   &:focus {
     box-shadow: $btn-shadow-dark;
+    background: $accent-color-hover;
+
   }
 }

--- a/src/sass/components/_order-form.scss
+++ b/src/sass/components/_order-form.scss
@@ -162,18 +162,21 @@
   text-align: center;
   letter-spacing: 0.1em;
   text-transform: uppercase;
-  color: $accent-color;
+  color: $primary-white-color;
   width: 280px;
   height: 56px;
-  background: $background-btn;
+  background: $accent-color;
   box-shadow: $btn-shadow;
   border-radius: 30.5px;
   padding: 16px 32px;
   cursor: pointer;
-  transition: box-shadow $main-duration $timing-function;
+  transition: box-shadow, $main-duration $timing-function;
+  transition: background, $main-duration $timing-function;
+
   &:hover,
   &:focus {
     box-shadow: $btn-shadow-dark;
+    background: $accent-color-hover;
   }
   @media screen and (min-width: 768px) {
     width: 177px;

--- a/src/sass/utils/_variables.scss
+++ b/src/sass/utils/_variables.scss
@@ -1,9 +1,11 @@
-$accent-color: #487996;
+$accent-color: #008cef;
+$accent-color-hover: #0d73bd;
+
 $text-descr: #2b2b2b;
 $primary-white-color: #ffffff;
 $timing-function: cubic-bezier(0.4, 0, 0.2, 1);
 $main-duration: 250ms;
-$btn-shadow: -10px -10px 20px #ffffff, 10px 10px 20px rgba(72, 121, 150, 0.1),
+$btn-shadow: -10px -10px 20px #ffffff, 10px 10px 20px rgba(72, 121, 150, 0.2),
   5px 5px 10px rgba(72, 121, 150, 0.25), -5px -5px 10px #ffffff;
 $btn-shadow-dark: -10px -10px 20px #ffffff,
   10px 10px 20px rgba(72, 121, 150, 0.5), 5px 5px 10px rgba(72, 121, 150, 0.25),


### PR DESCRIPTION
[refactor] change accent background color of order-btn and order-form__submit-btn

*Styles*
- Change accent background color of order-btn from $background-btn to $accent-color:#008cef in _order-btn.scss
- Change text color of order-btn from $accent-color to $primary-white-color in _order-btn.scss
- Change accent background color of order-form__submit-btn from $background-btn to $accent-color:#008cef in _order-btn.scss
- Change text color of order-form__submit-btn from $accent-color to $primary-white-color in _order-btn.scss
- Create veriables $accent-color-hover: #0d73bd
- Add hover $accent-color-hover: #0d73bd on order-btn in _order-btn.scss and order-form__submit-btn in _order-form.scss
- Add transition for background color on order-btn in _order-btn.scss and order-form__submit-btn in _order-form.scss
- Change opacity of veriables $btn-shadow: from 0.1 to 0.2