### PR TITLE
[fix] Fix icons arrow size at gallery-overlay

### DIFF
--- a/src/partials/components/_gallery-overlay.html
+++ b/src/partials/components/_gallery-overlay.html
@@ -5,13 +5,13 @@
 >
   <div class="gallery-overlay__wrapper">
     <div class="gallery-overlay__symbol-left-wrap">
-      <svg class="gallery-overlay__symbol-left">
+      <svg class="gallery-overlay__symbol-left" viewbox="0 0 23 40">
         <use href="/images/sprite.svg#icon-arrow-left"></use>
       </svg>
     </div>
 
     <div class="gallery-overlay__symbol-right-wrap">
-      <svg class="gallery-overlay__symbol-right">
+      <svg class="gallery-overlay__symbol-right" viewbox="0 0 23 40">
         <use href="/images/sprite.svg#icon-arrow-right"></use>
       </svg>
     </div>


### PR DESCRIPTION
_HTML-markup_

- add viewbox to svg-icons with correct sizes.