### PR TITLE
[fix] Fix clipping of image on page "3D scanning"

### DIFF
--- a/src/sass/pages/_3d-scanning.scss
+++ b/src/sass/pages/_3d-scanning.scss
@@ -53,6 +53,12 @@
   }
 }
 
+.scan-hero__descrip-box-position {
+  @media screen and (min-width: 1440px) {
+    margin-bottom: 100px;
+  }
+}
+
 .scan-hero__descrip {
   margin-bottom: $paragraph-font-size-mobile-and-tablet;
 
@@ -376,8 +382,6 @@
     }
   }
 }
-
-
 
 .scan-process__descrip-span {
   display: block;


### PR DESCRIPTION
1. Add a bottom margin to the block on the "3D scanning" page to correct image cropping.