### PR TITLE
[fix] Center 3d-printing images between 320px & 768px breakpoints

### DIFF
--- a/src/sass/pages/_3d-printing.scss
+++ b/src/sass/pages/_3d-printing.scss
@@ -100,6 +100,9 @@
   overflow: hidden;
 
   box-shadow: 20px 20px 80px rgba(0, 0, 0, 0.15);
+  @media screen and (min-width: 320px) and (max-width: 767px) {
+    margin: 0 auto 16px auto;
+  }
   @media screen and (min-width: 768px) {
     min-width: 247px;
     height: 341px;


### PR DESCRIPTION
Made centering of images on the 3D printing page in the mobile version of the site.